### PR TITLE
8 support visualization in rviz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   tf
+  visualization_msgs
 )
 
 find_package(Eigen3 REQUIRED)
@@ -108,6 +109,7 @@ add_library(${PROJECT_NAME}_ros
   src/detect_tags_in_ros_image.cpp
   src/tag_detection_to_msg.cpp
   src/tag_publisher.cpp
+  src/visualize_tags.cpp
 )
 
 ## Add cmake target dependencies of the executable/library

--- a/include/april_tag_ros/april_tag_nodelet.h
+++ b/include/april_tag_ros/april_tag_nodelet.h
@@ -10,6 +10,7 @@
 #include <sensor_msgs/CameraInfo.h>
 
 #include "april_tag_ros/tag_publisher.h"
+#include "april_tag_ros/visualize_tags.h"
 
 namespace april_tag
 {
@@ -20,6 +21,7 @@ public:
 
 private:
   std::unique_ptr<TagPublisher> tag_publisher_;
+  std::unique_ptr<VisualizeTags> visualize_tags_;
   ros::Timer initialization_thread_;
 };
 }

--- a/include/april_tag_ros/visualize_tags.h
+++ b/include/april_tag_ros/visualize_tags.h
@@ -1,0 +1,31 @@
+/** \author James Giller */
+#ifndef APRIL_TAG_VISUALIZE_TAGS_H
+#define APRIL_TAG_VISUALIZE_TAGS_H
+
+#include <ros/node_handle.h>
+
+#include "april_tag/AprilTagList.h"
+
+namespace april_tag
+{
+/**
+ * @brief Publishes visualization_msgs/MarkerArray msgs containing all tags detected in any one image
+ */
+class VisualizeTags
+{
+public:
+  /**
+   * @brief this will publish MarkerArrays to 'visualize_tag_array' topic
+   * @param nh Markers will share the namespace of the node
+   */
+  VisualizeTags(ros::NodeHandle &nh);
+
+private:
+  void publishMarkersForTags_(const AprilTagListConstPtr &list, std::string marker_ns, double tag_size_m);
+
+  ros::Publisher tag_marker_publisher_;
+  ros::Subscriber tag_list_subscriber_;
+};
+}
+
+#endif // APRIL_TAG_VISUALIZE_TAGS_H

--- a/launch/april_tag.launch
+++ b/launch/april_tag.launch
@@ -4,6 +4,8 @@
   <arg name="principal_point_x_px" default="" />
   <arg name="principal_point_y_px" default="" />
 
+  <arg name="publish_visualization_markers" default="false" />
+
   <arg name="camera_ns" doc="namespace in which camera's image_raw topic exists e.g. /usb_cam" />
   <arg name="image_topic" default="/image_raw" />
   <arg name="tag_size_cm" doc="length of the edge of the black frame in cms" />
@@ -17,5 +19,7 @@
       <param name="focal_length_y_px" value="$(arg focal_length_y_px)" />
       <param name="principal_point_x_px" value="$(arg principal_point_x_px)" />
       <param name="principal_point_y_px" value="$(arg principal_point_y_px)" />
+
+      <param name="publish_visualization_markers" value="$(arg publish_visualization_markers)" />
     </node>
 </launch>

--- a/launch/nodelet.launch
+++ b/launch/nodelet.launch
@@ -5,7 +5,9 @@
   <arg name="focal_length_y_px" default="" />
   <arg name="principal_point_x_px" default="" />
   <arg name="principal_point_y_px" default="" />
-  
+
+  <arg name="publish_visualization_markers" default="false" />
+
   <arg name="camera_ns" doc="namespace in which camera's image_raw topic exists e.g. /usb_cam" />
   <arg name="image_topic" default="/image_raw" />
   <arg name="tag_size_cm" doc="length of the edge of the black frame in cms" />
@@ -20,5 +22,7 @@
     <param name="focal_length_y_px" value="$(arg focal_length_y_px)" />
     <param name="principal_point_x_px" value="$(arg principal_point_x_px)" />
     <param name="principal_point_y_px" value="$(arg principal_point_y_px)" />
+
+    <param name="publish_visualization_markers" value="$(arg publish_visualization_markers)" />
   </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -49,6 +49,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>visualization_msgs</build_depend>
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>geometry_msgs</run_depend>
@@ -58,7 +59,8 @@
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
-  
+  <run_depend>visualization_msgs</run_depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- You can specify that this package is a metapackage here: -->

--- a/src/april_tag_node.cpp
+++ b/src/april_tag_node.cpp
@@ -2,9 +2,12 @@
 // adapted from ros example and april tag examples - palash
 //
 
+#include <memory>
+
 #include <ros/ros.h>
 
 #include "april_tag_ros/tag_publisher.h"
+#include "april_tag_ros/visualize_tags.h"
 #include "AprilTags/Tag36h11.h"
 
 int main(int argc, char** argv)
@@ -21,6 +24,12 @@ int main(int argc, char** argv)
   try
   {
     april_tag::TagPublisher tag_publisher{nh, private_nh, AprilTags::tagCodes36h11, std::move(loggers)};
+    std::unique_ptr<april_tag::VisualizeTags> visualize_tags;
+
+    if(private_nh.param<bool>("publish_visualization_markers", false))
+    {
+      visualize_tags.reset(new april_tag::VisualizeTags(nh));
+    }
     ros::spin();
     return 0;
   }

--- a/src/april_tag_nodelet.cpp
+++ b/src/april_tag_nodelet.cpp
@@ -27,6 +27,10 @@ void AprilTagNodelet::onInit()
     try
     {
       tag_publisher_.reset(new TagPublisher(nh, private_nh, AprilTags::tagCodes36h11, std::move(loggers)));
+      if(private_nh.param<bool>("publish_visualization_markers", false))
+      {
+        visualize_tags_.reset(new april_tag::VisualizeTags(nh));
+      }
     }
     catch(const std::runtime_error &e)
     {

--- a/src/tag_publisher.cpp
+++ b/src/tag_publisher.cpp
@@ -76,8 +76,8 @@ void TagPublisher::detectAndPublishTags_(const sensor_msgs::ImageConstPtr &msg)
     if(detections.size() > 0)
     {
       detection_context_.time_and_place = msg->header;
-      AprilTagList tag_list;
-      std::transform(detections.begin(), detections.end(), std::back_inserter(tag_list.april_tags),
+      AprilTagListPtr tag_list{new AprilTagList};
+      std::transform(detections.begin(), detections.end(), std::back_inserter(tag_list->april_tags),
                      std::bind(tagDetectionToMsg, std::placeholders::_1, detection_context_));
       tag_list_pub_.publish(tag_list);
     }

--- a/src/tag_publisher.cpp
+++ b/src/tag_publisher.cpp
@@ -6,8 +6,6 @@
 #include <algorithm>
 #include <iterator>
 
-#include <visualization_msgs/MarkerArray.h>
-
 #include <boost/format.hpp>
 
 namespace april_tag

--- a/src/tag_publisher.cpp
+++ b/src/tag_publisher.cpp
@@ -6,11 +6,12 @@
 #include <algorithm>
 #include <iterator>
 
+#include <visualization_msgs/MarkerArray.h>
+
 #include <boost/format.hpp>
 
 namespace april_tag
 {
-
 TagPublisher::TagPublisher(ros::NodeHandle &nh, ros::NodeHandle &private_nh, const AprilTags::TagCodes &tag_codes,
                            TagPublisher::Loggers loggers) :
   detect_tags_{tag_codes},

--- a/src/visualize_tags.cpp
+++ b/src/visualize_tags.cpp
@@ -1,0 +1,55 @@
+#include "april_tag_ros/visualize_tags.h"
+
+#include <algorithm>
+
+#include <visualization_msgs/MarkerArray.h>
+
+#include <boost/bind.hpp>
+
+namespace april_tag
+{
+VisualizeTags::VisualizeTags(ros::NodeHandle &nh)
+{
+  double tag_size_cm;
+  if(!nh.getParam("tag_size_cm", tag_size_cm))
+  {
+    throw std::runtime_error{"Parameter 'tag_size_cm' is required but not set"};
+  }
+  const double tag_size_m = tag_size_cm / 100.0;
+
+  auto callback = boost::bind(&VisualizeTags::publishMarkersForTags_, this, _1, nh.getNamespace(), tag_size_m);
+
+  tag_marker_publisher_ = nh.advertise<visualization_msgs::MarkerArray>("visualize_tag_array", 1, true);
+  tag_list_subscriber_ = nh.subscribe<AprilTagList>("/april_tags", 1, callback);
+}
+
+void VisualizeTags::publishMarkersForTags_(const AprilTagListConstPtr &list, std::string marker_ns, double tag_size_m)
+{
+  const double thickness = 0.005;
+
+  visualization_msgs::MarkerArray tag_markers;
+  std::transform(list->april_tags.begin(), list->april_tags.end(), std::back_inserter(tag_markers.markers),
+                 [&, this](const AprilTag &tag) -> visualization_msgs::Marker {
+    const double thickness = 0.005;
+
+    visualization_msgs::Marker marker;
+    marker.header = tag.stamped.header;
+    marker.ns = marker_ns;
+    marker.id = tag.id;
+    marker.type = visualization_msgs::Marker::CUBE;
+    marker.action = visualization_msgs::Marker::ADD;
+    marker.pose = tag.stamped.pose;
+    marker.pose.position.z -= thickness / 2.0;
+    marker.scale.x = tag_size_m;
+    marker.scale.y = marker.scale.x;
+    marker.scale.z = thickness;
+    marker.color.a = 1.0;
+    marker.color.b = 1.0;
+    marker.lifetime = ros::Duration{1};
+
+    return marker;
+  });
+
+  tag_marker_publisher_.publish(tag_markers);
+}
+}


### PR DESCRIPTION
Closes #8 

Add a VisualizeTags class, which subscribes to AprilTagList topic on which detected tags are published, then publishes visualization_msgs/MarkerArray msgs to visualize the tags in RViz.

Make TagPublisher publish AprilTagListPtr so the topic communication with VisualizeTags is free (see [here](https://www.google.co.jp/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwiLqKLP74_XAhVThbwKHV2uBdcQygQILTAA&url=http%3A%2F%2Fwiki.ros.org%2Froscpp%2FOverview%2FPublishers%2520and%2520Subscribers%23Intraprocess_Publishing&usg=AOvVaw3oifAvEg9yGLD3omJwNZ-N))

Markers in the MarkerArray will be under the same namespace as the april_tag node/nodelet, and have ids that correspond to those in the tag family.